### PR TITLE
Add pathname to sending config message

### DIFF
--- a/src/internal/messages.ts
+++ b/src/internal/messages.ts
@@ -53,6 +53,7 @@ export type IMessageFromWorkshop =
 export interface ISendConfigToWorkshopMessage {
   type: MESSAGE_TYPES_TO_WORKSHOP.SENDING_CONFIG;
   config: IConfigDefinition;
+  pathname?: string; 
 }
 
 /**

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -81,6 +81,7 @@ export function useWorkshopContext<T extends IConfigDefinition>(
           sendMessageToWorkshop({
             type: MESSAGE_TYPES_TO_WORKSHOP.SENDING_CONFIG,
             config: configFields,
+            pathname: window.location.pathname,
           });
           return;
         case MESSAGE_TYPES_FROM_WORKSHOP.VALUE_CHANGE:
@@ -98,6 +99,7 @@ export function useWorkshopContext<T extends IConfigDefinition>(
     sendMessageToWorkshop({
       type: MESSAGE_TYPES_TO_WORKSHOP.SENDING_CONFIG,
       config: configFields,
+      pathname: window.location.pathname,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
Because the [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent) object itself only provides the `origin` property, which contains the protocol, hostname, and port, but not the full URL (including the path and query string), we should send the pathname of where the config is being sent from in order to fix a bug where we want to verify that the initial URL in the config for the custom widget is an exact match for the origin of the message. 