### PR TITLE
Add temporaryObjectSetRid as a field type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ const ExampleComponent = () => {
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { IWorkshopContext, useWorkshopContext } from "@osdk/workshop-iframe-custom-widget";
 import React from "react";
+import { HomeComponent, RouteOneComponent, RouteTwoComponent } from "./routes";
 
   export const RouterProviderWrapperWithWorkshopContext = () => {
     const workshopContext = useWorkshopContext(CONFIG);
@@ -182,9 +183,9 @@ import React from "react";
         [
           { path: "/", element: <HomeComponent loadedContext={loadedContext}/>}, 
           { path: "/route1", element: <RouteOneComponent loadedContext={loadedContext}/>}, 
+          { path: "/route2", element: <RouteTwoComponent loadedContext={loadedContext}/>}, 
           ...,
-        ],
-        ...
+        ]
       )
       return <RouterProvider router={router} />;
   }

--- a/README.md
+++ b/README.md
@@ -96,59 +96,109 @@ Here is an example React component that shows how to call `useWorkshopContext` w
 const ExampleComponent = () => {
   const workshopContext = useWorkshopContext(BASIC_CONFIG_DEFINITION);
 
-  if (isAsyncValue_Loading(workshopContext)) {
-    // Render a loading state
-  } else if (isAsyncValue_Loaded(workshopContext)) {
+  return visitLoadingState(workshopContext, {
+    loading: () => <>Loading...</>,
     // Must explicitly declare type for the loaded context value
-    const loadedWorkshopContext: IWorkshopContext<typeof BASIC_CONFIG_DEFINITION> = workshopContext.value;
+    succeeded: loadedWorkshopContext: IWorkshopContext<typeof BASIC_CONFIG_DEFINITION>  => {
+      const { stringField, workshopEvent, listOfField } = loadedWorkshopContext;
 
-    const { stringField, workshopEvent, listOfField } = loadedWorkshopContext;
+      // Examples of retrieving single field values.
+      const stringValue: IAsyncValue<string | undefined> = stringField.fieldValue;
 
-    // Examples of retrieving single field values.
-    const stringValue: IAsyncValue<string | undefined> = stringField.fieldValue;
+      // Examples of retrieving listOf field values.
+      listOfField.forEach(listItem => {
+          const booleanListValue: IAsyncValue<boolean[] | undefined> = listItem.booleanListField.fieldValue;
+      });
 
-    // Examples of retrieving listOf field values.
-    listOfField.forEach(listItem => {
-        const booleanListValue: IAsyncValue<boolean[] | undefined> = listItem.booleanListField.fieldValue;
-    });
+      // Examples of setting single field values.
+      stringField.setLoading();
+      stringField.setLoadedValue("Hello world!");
+      stringField.setReloadingValue("Hello world is reloading.");
+      stringField.setFailedWithError("Hello world failed to load.");
 
-    // Examples of setting single field values.
-    stringField.setLoading();
-    stringField.setLoadedValue("Hello world!");
-    stringField.setReloadingValue("Hello world is reloading.");
-    stringField.setFailedWithError("Hello world failed to load.");
-
-    // Examples of setting listOf field values.
-    listOfField.forEach((listItem, index) => {
-        listItem.booleanListField.setLoading();
-        listItem.booleanListField.setLoadedValue([true, false]);
-        listItem.booleanListField.setReloadingValue([false, true]);
-        listItem.booleanListField.setFailedWithError(`Failed to load on listOf layer ${index}`);
-    });
-
-
-    // Example of executing event. Takes a React MouseEvent, or undefined if not applicable
-    workshopEvent.executeEvent(undefined);
+      // Examples of setting listOf field values.
+      listOfField.forEach((listItem, index) => {
+          listItem.booleanListField.setLoading();
+          listItem.booleanListField.setLoadedValue([true, false]);
+          listItem.booleanListField.setReloadingValue([false, true]);
+          listItem.booleanListField.setFailedWithError(`Failed to load on listOf layer ${index}`);
+      });
 
 
-    return <div>Render something here.</div>;
-  } else if (isAsyncValue_FailedLoading(workshopContext)) {
-    // Render a failure state
-  }
+      // Example of executing event. Takes a React MouseEvent, or undefined if not applicable
+      workshopEvent.executeEvent(undefined);
+
+
+      return <div>Render something here.</div>;
+    }
+    reloading: _reloadingContext => <>Reloading...</>,
+    failed: _error => <>Error...</>, 
+  });
 };
 ```
 
 ## FAQ's
 
-1. Why is the context object returned by `useWorkshopContext` wrapped in an async loading state?
+1. For Ontology object set fields, should I use `objectSet` or `temporaryObjectSetRid`? 
+  
+  It depends on what version of [@osdk/client](https://www.npmjs.com/package/@osdk/client) you are using to query the Ontology from your app. You should use `objectSet`, which gives you the value of a objectTypeId with up to 10,000 primary keys if you are using [@osdk/client](https://www.npmjs.com/package/@osdk/client) version < 2.0, and `temporaryObjectSetRid` if you are using [@osdk/client](https://www.npmjs.com/package/@osdk/client) >= 2.0 as higher versions have the capabilities to materialize object sets from a temporary objectSet RID, and vice versa generate a temporary objectSet RID given a set of Ontology objects. Using `temporaryObjectSetRid` also removes the limitations of being restricted to single object type object sets, and the 10,000 limit. 
+
+  Note that we will soon be making a major bump to 2.0, due to this package deprecating the option to use `objectSet` fields, as we encourage consumers to move to using `temporaryObjectSetRid` to query from the Ontology allowing the ability to pass to and from Workshop object sets containing multi-object type object sets, and object sets of size over 10,000. 
+
+2. Where in my app should I call `useWorkshopContext`? 
+
+  `useWorkshopContext` should be called from the route that you plan to embed in Workshop. Each call of `useWorkshopContext` should map to one instance of the bidirectional iframe widget. For example, if you would like to set up your app such that route `/app1` and route `/app2` are each two distinct custom widgets, you should call `useWorkshopContext` per component rendered at those routes (a total of two calls). 
+  
+  Alternatively, if you want to set up your app such that your widget navigates to multiple routes, you will want to call `useWorkshopContext` once in the main component and pass the context fields to each route. An example of this is below: 
+
+  In main.tsx: 
+  ```typescript
+  import ReactDOM from "react-dom/client";
+  import { RouterProviderWrapperWithWorkshopContext } from "./MainComponent";
+   
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+  <RouterProviderWrapperWithWorkshopContext />,
+);
+  ```
+
+  In RouterProviderWrapperWithWorkshopContext.tsx: 
+  ```typescript
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { IWorkshopContext, useWorkshopContext } from "@osdk/workshop-iframe-custom-widget";
+import React from "react";
+
+  export const RouterProviderWrapperWithWorkshopContext = () => {
+    const workshopContext = useWorkshopContext(CONFIG);
+    return visitLoadingState(workshopContext, {
+      loading: () => <>Loading...</>,
+      succeeded: loadedContext => <LoadedComprehensiveExample loadedContext={loadedContext} />, 
+      reloading: _reloadingContext => <>Reloading...</>,
+      failed: _error => <>Error...</>, 
+    })
+  }
+
+  const LoadedRouterProviderWrapperWithWorkshopContext = (props: { loadedContext: IWorkshopContext<typeof CONFIG> }) => {
+      const router = createBrowserRouter(
+        [
+          { path: "/", element: <HomeComponent loadedContext={loadedContext}/>}, 
+          { path: "/route1", element: <RouteOneComponent loadedContext={loadedContext}/>}, 
+          ...,
+        ],
+        ...
+      )
+      return <RouterProvider router={router} />;
+  }
+  ```
+
+3. Why is the context object returned by `useWorkshopContext` wrapped in an async loading state?
 
    Please refer to the diagram Figure 1.a and 1.b. When your custom app is iframed inside of Workshop, the context object will not exist until Workshop accepts the config parameter and as such will be in a loading state until it is accepted. It may also be rejected by Workshop and as such will be wrapped in a failed to load async state with an accompanying error message.
 
-2. Why should I provide default values when defining the config passed to `useWorkshopContext`?
+4. Why should I provide default values when defining the config passed to `useWorkshopContext`?
 
    During development when your custom app is not iframed in Workshop, its not receiving any values and as such it would make development difficult if all you had to work with were a forever loading context object or a loaded context object with null values. Allowing you to provide default values when defining the config that gets translated to the context object returned by `useWorkshopContext` helps you during development when the app is not being iframed, as the plugin will detect whether your app is being iframed and if not, will return a loaded context object populated with your default values.
 
-3. Why is each value inside the context object returned by `useWorkshopContext` wrapped in with an async loading state?
+5. Why is each value inside the context object returned by `useWorkshopContext` wrapped in with an async loading state?
 
    Workshop's variables each have an async loading state, as variables could come from asynchronous execution, such as a function that takes 10 seconds to return a value. Having a 1:1 match between the types in the context object and Workshop means that the two have a consistent view of variable values. If a variable in Workshop goes into a loading state or fails to load, this async state is passed to the iframed app allowing you to decide how to handle cases where one of the parameters is not available or currently might be re-loading. For example when implementing a custom submission form, you might want to disable the submission button if some of the inputs to your form hasn't loaded yet or are currently re-loading.
    

--- a/src/example/Example.tsx
+++ b/src/example/Example.tsx
@@ -51,6 +51,7 @@ const LoadedComprehensiveExample: React.FC<{
     timestampField,
     stringListField,
     objectSetField,
+    temporaryObjectSetRidField,
     event,
     booleanListField,
     numberListField,
@@ -73,11 +74,12 @@ const LoadedComprehensiveExample: React.FC<{
   const timestampFieldValue: IAsyncValue<Date | undefined> =
     timestampField.fieldValue;
 
+  // Use https://www.npmjs.com/package/@osdk/client < 2.0 to query Ontology objects
   const objectSetFieldValue: IAsyncValue<ObjectSetLocators | undefined> =
     objectSetField.fieldValue;
-  // Example usage of objectSetFieldValue's primary keys to query for objects using osdk's client:
-  //      const primaryKeys: string[] = isAsyncValueLoaded(objectSetFieldValue) ? objectSetFieldValue.value.primaryKeys : [];
-  //      const housesfilteredByPrimaryKey: ObjectSet<RottenTomatoesMovies> = client.ontology.objects.RottenTomatoesMovies.where(query => query.rottenTomatoesLink.containsAnyTerm(primaryKeys.join(" ")));
+
+  // Use https://www.npmjs.com/package/@osdk/client version >= 2.0 to query Ontology objects
+  const temporaryObjectSetRidFieldValue: IAsyncValue<string | undefined> = temporaryObjectSetRidField.fieldValue;
 
   const stringListFieldValue: IAsyncValue<string[] | undefined>  =
     stringListField.fieldValue;
@@ -163,6 +165,8 @@ const LoadedComprehensiveExample: React.FC<{
     {timestampFieldValue}
     <br />
     {objectSetFieldValue}
+    <br /> 
+    {temporaryObjectSetRidFieldValue}
     <br />
     {stringListFieldValue}
     <br />

--- a/src/example/ExampleConfig.ts
+++ b/src/example/ExampleConfig.ts
@@ -18,6 +18,7 @@ export const COMPREHENSIVE_EXAMPLE_CONFIG = [
     fieldId: "stringField",
     field: {
       type: "single",
+      label: "String field",
       fieldValue: {
         type: "inputOutput",
         variableType: {
@@ -25,14 +26,13 @@ export const COMPREHENSIVE_EXAMPLE_CONFIG = [
           defaultValue: "test",
         },
       },
-      label: "Input string (title)",
     },
   },
   {
     fieldId: "numberField",
     field: {
       type: "single",
-      label: "Input number",
+      label: "Number field",
       fieldValue: {
         type: "inputOutput",
         variableType: {
@@ -46,7 +46,7 @@ export const COMPREHENSIVE_EXAMPLE_CONFIG = [
     fieldId: "booleanField",
     field: {
       type: "single",
-      label: "Input boolean",
+      label: "Boolean field",
       fieldValue: {
         type: "inputOutput",
         variableType: {
@@ -60,7 +60,7 @@ export const COMPREHENSIVE_EXAMPLE_CONFIG = [
     fieldId: "dateField",
     field: {
       type: "single",
-      label: "Input date",
+      label: "Date field",
       fieldValue: {
         type: "inputOutput",
         variableType: {
@@ -74,7 +74,7 @@ export const COMPREHENSIVE_EXAMPLE_CONFIG = [
     fieldId: "timestampField",
     field: {
       type: "single",
-      label: "Input timestamp",
+      label: "Timestamp field",
       fieldValue: {
         type: "inputOutput",
         variableType: {
@@ -88,10 +88,11 @@ export const COMPREHENSIVE_EXAMPLE_CONFIG = [
     fieldId: "objectSetField",
     field: {
       type: "single",
-      label: "Input object set",
+      label: "Object set field (limited to first 10,000)",
       fieldValue: {
         type: "inputOutput",
         variableType: {
+           // Consider using temporaryObjectSetRid instead, which is not limited to first 10,000 objects
           type: "objectSet",
           objectTypeId: "rotten-tomatoes-movies",
           defaultValue: {
@@ -101,6 +102,20 @@ export const COMPREHENSIVE_EXAMPLE_CONFIG = [
         },
       },
     },
+  },
+  {
+    // Only compatible with https://www.npmjs.com/package/@osdk/client > 2.0
+    fieldId: "temporaryObjectSetRidField", 
+    field: {
+      type: "single", 
+      label: "Object set field (via temporary object set rid)", 
+      fieldValue: {
+        type: "inputOutput", 
+        variableType: {
+          type: "temporaryObjectSetRid", 
+        }
+      }
+    }
   },
   {
     fieldId: "stringListField",

--- a/src/internal/variableTypeWithDefaultValue.ts
+++ b/src/internal/variableTypeWithDefaultValue.ts
@@ -28,7 +28,8 @@ export type IVariableType_WithDefaultValue =
   | IVariableType_DateList_WithDefaultValue
   | IVariableType_TimestampList_WithDefaultValue
   // | IVariableType_Struct // TODO: Struct support is coming, but is not fully supported yet
-  | IVariableType_ObjectSet_WithDefaultValue;
+  | IVariableType_ObjectSet_WithDefaultValue
+  | IVariableType_TemporaryObjectSetRidWithDefaultValue; 
 
 // Workshop only supports struct fields containing the following types. Nested structs are not yet supported
 export type IStructVariableFieldType_WithDefaultValue =
@@ -42,7 +43,8 @@ export type IStructVariableFieldType_WithDefaultValue =
   | IVariableType_NumberList_WithDefaultValue
   | IVariableType_DateList_WithDefaultValue
   | IVariableType_TimestampList_WithDefaultValue
-  | IVariableType_ObjectSet_WithDefaultValue;
+  | IVariableType_ObjectSet_WithDefaultValue
+  | IVariableType_TemporaryObjectSetRidWithDefaultValue;
 
 export interface IVariableType_String_WithDefaultValue {
   type: "string";
@@ -108,4 +110,9 @@ export interface IVariableType_ObjectSet_WithDefaultValue {
   type: "objectSet";
   objectTypeId: string;
   defaultValue?: ObjectSetLocators;
+}
+
+export interface IVariableType_TemporaryObjectSetRidWithDefaultValue {
+  type: "temporaryObjectSetRid"; 
+  defaultValue?: string;
 }

--- a/src/types/workshopContext.ts
+++ b/src/types/workshopContext.ts
@@ -84,6 +84,8 @@ export type VariableTypeToValueType<T extends IVariableType_WithDefaultValue> =
     ? Date
     : T extends { type: "objectSet" }
     ? ObjectSetLocators
+    : T extends { type: "temporaryObjectSetRid" }
+    ? string
     : T extends { type: "string-list" }
     ? string[]
     : T extends { type: "boolean-list" }
@@ -125,6 +127,8 @@ export type VariableTypeToValueTypeToSet<
   ? Date
   : T extends { type: "objectSet" }
   ? OntologyObject[]
+  : T extends { type: "temporaryObjectSetRid" }
+  ? string
   : T extends { type: "string-list" }
   ? string[]
   : T extends { type: "boolean-list" }


### PR DESCRIPTION
New field type `temporaryObjectSetRid`, which has a value type of string.

Update comments and README to clarify that consumers should use `objectSet` if using [@osdk/client](https://www.npmjs.com/package/@osdk/client) version < 2.0 to query for Ontology objects, and use `temporaryObjectSetRid` if version >= 2.0 to query for Ontology objects. 

Also added note in README that we will be deprecating the `objectSet` field type in the next major bump to encourage consumers to move to `temporaryObjectSetRid` as there are less restrictions including: 
- able to pass multi object type object sets between custom widget and Workshop 
- able to pass object sets of >10,000 objects between custom widget and Workshop 

A few cosmetic changes in README: 
- Prefer using visitor`visitLoadingState` in the examples instead of if statements 
- Added FAQ "Where in my app should I call `useWorkshopContext`?" as this has proven itself to be a FAQ 
- Cleaned up example config labels 