### PR TITLE
Bug: By empty set theory, if an array is empty, then everything in the array isOntologyObject

### DIFF
--- a/src/transform-config/utils.ts
+++ b/src/transform-config/utils.ts
@@ -109,10 +109,12 @@ export function maybeTransformValueToSetToValueMapTypes<
   variableType: IVariableType_WithDefaultValue,
   value?: VariableTypeToValueTypeToSet<V>
 ): IVariableValue | undefined {
+  // Empty primitive arrays 
+  if (Array.isArray(value) && value.length === 0 && variableType.type !== "objectSet") {
+    return [];
+  }
+  // OntologyObject arrays
   if (Array.isArray(value) && value.every(isOntologyObject)) {
-    if (value.length === 0 && variableType.type !== "objectSet") {
-      return [];
-    }
     if (
       value.every(
         (ontologyObject) => typeof ontologyObject.$primaryKey === "string"
@@ -161,10 +163,12 @@ export function maybeTransformValueToSetToWorkshopValue<
   variableType: IVariableType_WithDefaultValue,
   value?: VariableTypeToValueTypeToSet<V>
 ): IVariableToSet | undefined {
+  // Empty primitve arrays 
+  if (Array.isArray(value) && value.length === 0 && variableType.type !== "objectSet") {
+    return [];
+  }
+  // OntologyObject arrays
   if (Array.isArray(value) && value.every(isOntologyObject)) {
-    if (value.length === 0 && variableType.type !== "objectSet") {
-      return [];
-    }
     return {
       objectRids: value
         .slice(0, MAX_OBJECTS)

--- a/src/transform-config/utils.ts
+++ b/src/transform-config/utils.ts
@@ -110,6 +110,9 @@ export function maybeTransformValueToSetToValueMapTypes<
   value?: VariableTypeToValueTypeToSet<V>
 ): IVariableValue | undefined {
   if (Array.isArray(value) && value.every(isOntologyObject)) {
+    if (value.length === 0 && variableType.type !== "objectSet") {
+      return [];
+    }
     if (
       value.every(
         (ontologyObject) => typeof ontologyObject.$primaryKey === "string"
@@ -159,6 +162,9 @@ export function maybeTransformValueToSetToWorkshopValue<
   value?: VariableTypeToValueTypeToSet<V>
 ): IVariableToSet | undefined {
   if (Array.isArray(value) && value.every(isOntologyObject)) {
+    if (value.length === 0 && variableType.type !== "objectSet") {
+      return [];
+    }
     return {
       objectRids: value
         .slice(0, MAX_OBJECTS)


### PR DESCRIPTION
When setting an array as the empty list `[]` by empty set theory, the transform converter will pass the `Array.isArray(value) && value.every(isOntologyObject)` check so we'll end up sending 
```
return {
      objectRids: []
    };
```
as the value to workshop which is incorrect. Workshop will try to set an array variable's value as this but it won't work since the type is wrong so nothing happens. 

Noticed this in console there is a warning ```An IVariableType list must be associated with a IEvaluatedValueType array.``` and after doing some logging found that Workshop was rejecting a value to set on an array variable that was not an array value and was ``` { objectRids: [] };```