### PR TITLE
feat: adding setHeight to useWorkshopContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const ExampleComponent = () => {
 
 You can dynamically control the maximum height of your iframe when embedded in Workshop using the `setAutoMaxHeight` function that's returned as part of the workshop context. This allows your application to adjust its container height based on content changes, user interactions, or any other factors.
 
-**Important Note:** The `setAutoMaxHeight` function only works when the Workshop widget's height is set to "auto (max)" in the Workshop widget settings. If the max height configured in Workshop is less than the height sent by `setAutoMaxHeight`, the Workshop max height will override it, and the custom application widget will have a scroll bar for the difference between heights.
+**Important Note:** The `setAutoMaxHeight` function only works when the Workshop widget's height is set to "Auto (max)" in the Workshop widget's "Display" settings. If the max height configured in Workshop is less than the height sent by `setAutoMaxHeight`, the Workshop max height will override it, and the custom application widget will likely include a scroll bar to account for the overflow.
 
 ### Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const ExampleComponent = () => {
 
 You can dynamically control the maximum height of your iframe when embedded in Workshop using the `setAutoMaxHeight` function that's returned as part of the workshop context. This allows your application to adjust its container height based on content changes, user interactions, or any other factors.
 
-**Important Note:** The `setAutoMaxHeight` function only works when the Workshop widget's height is set to "auto (max)" in the Workshop widget settings.
+**Important Note:** The `setAutoMaxHeight` function only works when the Workshop widget's height is set to "auto (max)" in the Workshop widget settings. If the max height configured in Workshop is less than the height sent by `setAutoMaxHeight`, the Workshop max height will override it, and the custom application widget will have a scroll bar for the difference between heights.
 
 ### Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can dynamically control the maximum height of your iframe when embedded in W
 ### Basic Usage
 
 ```typescript
-const workshopContext = useWorkshopContext(configFields);
+const workshopContext = useWorkshopContext(configFields, { enableSetAutoMaxHeight: true });
 
 return visitLoadingState(workshopContext, {
   loading: () => <>Loading...</>,

--- a/README.md
+++ b/README.md
@@ -137,6 +137,30 @@ const ExampleComponent = () => {
 };
 ```
 
+## Dynamic Height Control
+
+You can dynamically control the height of your iframe when embedded in Workshop using the `setHeight` function that's returned as part of the workshop context. This allows your application to adjust its container height based on content changes, user interactions, or any other factors.
+
+### Basic Usage
+
+```typescript
+const workshopContext = useWorkshopContext(configFields);
+
+return visitLoadingState(workshopContext, {
+  loading: () => <>Loading...</>,
+  succeeded: (context) => {
+    // Set the height to 500px
+    context.setHeight(500);
+    
+    return <div>Your content here</div>;
+  },
+  reloading: _reloadingContext => <>Reloading...</>,
+  failed: _error => <>Error...</>,
+});
+```
+
+This approach gives you complete control over when and how to adjust the iframe's height. The `setHeight` function only has an effect when your application is running inside an iframe in Workshop.
+
 ## FAQ's
 
 1. For Ontology object set fields, should I use `objectSet` or `temporaryObjectSetRid`? 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ const ExampleComponent = () => {
 
 ## Dynamic Height Control
 
-You can dynamically control the height of your iframe when embedded in Workshop using the `setHeight` function that's returned as part of the workshop context. This allows your application to adjust its container height based on content changes, user interactions, or any other factors.
+You can dynamically control the maximum height of your iframe when embedded in Workshop using the `setAutoMaxHeight` function that's returned as part of the workshop context. This allows your application to adjust its container height based on content changes, user interactions, or any other factors.
+
+**Important Note:** The `setAutoMaxHeight` function only works when the Workshop widget's height is set to "auto (max)" in the Workshop widget settings.
 
 ### Basic Usage
 
@@ -149,8 +151,8 @@ const workshopContext = useWorkshopContext(configFields);
 return visitLoadingState(workshopContext, {
   loading: () => <>Loading...</>,
   succeeded: (context) => {
-    // Set the height to 500px
-    context.setHeight(500);
+    // Set the maximum height to 500px
+    context.setAutoMaxHeight(500);
     
     return <div>Your content here</div>;
   },

--- a/src/example/Example.tsx
+++ b/src/example/Example.tsx
@@ -38,7 +38,8 @@ export const Example = () => {
 };
 
 /**
- * This is an example of how to set the height of the iframe in Workshop.
+ * This is an example of how to set the maximum height of the iframe in Workshop.
+ * Note: This only works when the Workshop widget's height is set to "auto (max)".
  */
 export const IframeHeightExample = () => {
   const workshopContext = useWorkshopContext(COMPREHENSIVE_EXAMPLE_CONFIG);
@@ -47,8 +48,8 @@ export const IframeHeightExample = () => {
   return visitLoadingState(workshopContext, {
     loading: () => <>Loading...</>,
     succeeded: loadedContext => {
-      // Set the iframe height to 500 pixels
-      loadedContext.setHeight(500);
+      // Set the iframe maximum height to 500 pixels
+      loadedContext.setAutoMaxHeight(500);
       return <>Iframe height set to 500 pixels</>;
     }, 
     reloading: _reloadingContext => <>Reloading...</>,

--- a/src/example/Example.tsx
+++ b/src/example/Example.tsx
@@ -38,6 +38,25 @@ export const Example = () => {
 };
 
 /**
+ * This is an example of how to set the height of the iframe in Workshop.
+ */
+export const IframeHeightExample = () => {
+  const workshopContext = useWorkshopContext(COMPREHENSIVE_EXAMPLE_CONFIG);
+
+  // Use a visitor function to render based on the async status of the workshop context object
+  return visitLoadingState(workshopContext, {
+    loading: () => <>Loading...</>,
+    succeeded: loadedContext => {
+      // Set the iframe height to 500 pixels
+      loadedContext.setHeight(500);
+      return <>Iframe height set to 500 pixels</>;
+    }, 
+    reloading: _reloadingContext => <>Reloading...</>,
+    failed: _error => <>Error...</>, 
+  });
+};
+
+/**
  * This is an example of how to use values and setter methods inside of the context object.
  */
 const LoadedComprehensiveExample: React.FC<{

--- a/src/example/Example.tsx
+++ b/src/example/Example.tsx
@@ -17,7 +17,7 @@ import {
   IAsyncValue,
   visitLoadingState,
 } from "../types/loadingState";
-import { IWorkshopContext } from "../types/workshopContext";
+import { IWorkshopContextWithHeight } from "../types/workshopContext";
 import { useWorkshopContext } from "../";
 import { ObjectSetLocators } from "../types";
 
@@ -26,7 +26,7 @@ import { ObjectSetLocators } from "../types";
  * retrieving values or setting values.
  */
 export const Example = () => {
-  const workshopContext = useWorkshopContext(COMPREHENSIVE_EXAMPLE_CONFIG);
+  const workshopContext = useWorkshopContext<typeof COMPREHENSIVE_EXAMPLE_CONFIG>(COMPREHENSIVE_EXAMPLE_CONFIG);
 
   // Use a visitor function to render based on the async status of the workshop context object
   return visitLoadingState(workshopContext, {
@@ -61,7 +61,7 @@ export const IframeHeightExample = () => {
  * This is an example of how to use values and setter methods inside of the context object.
  */
 const LoadedComprehensiveExample: React.FC<{
-  loadedWorkshopContext: IWorkshopContext<typeof COMPREHENSIVE_EXAMPLE_CONFIG>;
+  loadedWorkshopContext: IWorkshopContextWithHeight<typeof COMPREHENSIVE_EXAMPLE_CONFIG>;
 }> = (props) => {
   const {
     stringField,

--- a/src/example/Example.tsx
+++ b/src/example/Example.tsx
@@ -38,7 +38,7 @@ export const Example = () => {
 
 /**
  * This is an example of how to set the maximum height of the iframe in Workshop.
- * Note: This only works when the Workshop widget's height is set to "auto (max)".
+ * Note: This only works when the Workshop widget's height is set to "Auto (max)".
  */
 export const IframeHeightExample = () => {
   const workshopContext = useWorkshopContext(COMPREHENSIVE_EXAMPLE_CONFIG, { enableSetAutoMaxHeight: true });

--- a/src/example/Example.tsx
+++ b/src/example/Example.tsx
@@ -17,7 +17,7 @@ import {
   IAsyncValue,
   visitLoadingState,
 } from "../types/loadingState";
-import { IWorkshopContextWithHeight } from "../types/workshopContext";
+import { IWorkshopContext } from "../types/workshopContext";
 import { useWorkshopContext } from "../";
 import { ObjectSetLocators } from "../types";
 
@@ -27,7 +27,6 @@ import { ObjectSetLocators } from "../types";
  */
 export const Example = () => {
   const workshopContext = useWorkshopContext<typeof COMPREHENSIVE_EXAMPLE_CONFIG>(COMPREHENSIVE_EXAMPLE_CONFIG);
-
   // Use a visitor function to render based on the async status of the workshop context object
   return visitLoadingState(workshopContext, {
     loading: () => <>Loading...</>,
@@ -42,7 +41,7 @@ export const Example = () => {
  * Note: This only works when the Workshop widget's height is set to "auto (max)".
  */
 export const IframeHeightExample = () => {
-  const workshopContext = useWorkshopContext(COMPREHENSIVE_EXAMPLE_CONFIG);
+  const workshopContext = useWorkshopContext(COMPREHENSIVE_EXAMPLE_CONFIG, { enableSetAutoMaxHeight: true });
 
   // Use a visitor function to render based on the async status of the workshop context object
   return visitLoadingState(workshopContext, {
@@ -61,7 +60,7 @@ export const IframeHeightExample = () => {
  * This is an example of how to use values and setter methods inside of the context object.
  */
 const LoadedComprehensiveExample: React.FC<{
-  loadedWorkshopContext: IWorkshopContextWithHeight<typeof COMPREHENSIVE_EXAMPLE_CONFIG>;
+  loadedWorkshopContext: IWorkshopContext<typeof COMPREHENSIVE_EXAMPLE_CONFIG>;
 }> = (props) => {
   const {
     stringField,

--- a/src/internal/messages.ts
+++ b/src/internal/messages.ts
@@ -83,6 +83,7 @@ export interface IExecuteWorkshopEvent {
  */
 export interface ISetHeightMessage {
   type: MESSAGE_TYPES_TO_WORKSHOP.SET_HEIGHT;
+  iframeWidgetId: string;
   height: number;
 }
 

--- a/src/internal/messages.ts
+++ b/src/internal/messages.ts
@@ -21,7 +21,7 @@ export enum MESSAGE_TYPES_TO_WORKSHOP {
   SENDING_CONFIG = "react-app-sending-config",
   SETTING_VALUE = "react-app-setting-value",
   EXECUTING_EVENT = "react-app-executing-event",
-  SET_HEIGHT = "react-app-set-height",
+  SET_AUTO_MAX_HEIGHT = "react-app-set-auto-max-height",
 }
 
 export enum MESSAGE_TYPES_FROM_WORKSHOP {

--- a/src/internal/messages.ts
+++ b/src/internal/messages.ts
@@ -82,7 +82,7 @@ export interface IExecuteWorkshopEvent {
  * Sets the height of the iframe in Workshop.
  */
 export interface ISetHeightMessage {
-  type: MESSAGE_TYPES_TO_WORKSHOP.SET_HEIGHT;
+  type: MESSAGE_TYPES_TO_WORKSHOP.SET_AUTO_MAX_HEIGHT;
   iframeWidgetId: string;
   height: number;
 }

--- a/src/internal/messages.ts
+++ b/src/internal/messages.ts
@@ -21,6 +21,7 @@ export enum MESSAGE_TYPES_TO_WORKSHOP {
   SENDING_CONFIG = "react-app-sending-config",
   SETTING_VALUE = "react-app-setting-value",
   EXECUTING_EVENT = "react-app-executing-event",
+  SET_HEIGHT = "react-app-set-height",
 }
 
 export enum MESSAGE_TYPES_FROM_WORKSHOP {
@@ -36,7 +37,8 @@ export enum MESSAGE_TYPES_FROM_WORKSHOP {
 export type IMessageToWorkshop =
   | ISendConfigToWorkshopMessage
   | ISetWorkshopValue
-  | IExecuteWorkshopEvent;
+  | IExecuteWorkshopEvent
+  | ISetHeightMessage;
 
 /**
  * Messages that can be recieved from Workshop
@@ -74,6 +76,14 @@ export interface IExecuteWorkshopEvent {
   iframeWidgetId: string;
   eventLocator: ILocator;
   mouseEvent?: MouseEvent;
+}
+
+/**
+ * Sets the height of the iframe in Workshop.
+ */
+export interface ISetHeightMessage {
+  type: MESSAGE_TYPES_TO_WORKSHOP.SET_HEIGHT;
+  height: number;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-export type { IWorkshopContext } from "./workshopContext";
+export type { IWorkshopContext, IWorkshopContextWithHeight } from "./workshopContext";
 export * from "./loadingState";
 export * from "./objectSetLocators";
 export * from "./configDefinition";

--- a/src/types/workshopContext.ts
+++ b/src/types/workshopContext.ts
@@ -202,3 +202,16 @@ export type IWorkshopContextField<
   T extends IConfigDefinition,
   V extends IVariableType_WithDefaultValue
 > = ValueAndSetterMethods<V> | ExecutableEvent | IWorkshopContext<T>[];
+
+/**
+ * Extends the IWorkshopContext with a setHeight function
+ */
+export type IWorkshopContextWithHeight<T extends IConfigDefinition> = IWorkshopContext<T> & {
+  /**
+   * Sets the maximum height of the iframe in Workshop.
+   * Only has an effect when the app is running inside an iframe AND
+   * the Workshop widget's height is set to "auto (max)".
+   * @param height The maximum height in pixels
+   */
+  setAutoMaxHeight: (height: number) => void;
+};

--- a/src/types/workshopContext.ts
+++ b/src/types/workshopContext.ts
@@ -204,9 +204,20 @@ export type IWorkshopContextField<
 > = ValueAndSetterMethods<V> | ExecutableEvent | IWorkshopContext<T>[];
 
 /**
- * Extends the IWorkshopContext with a setHeight function
+ * Options for useWorkshopContext
  */
-export type IWorkshopContextWithHeight<T extends IConfigDefinition> = IWorkshopContext<T> & {
+export interface IWorkshopContextOptions {
+  /**
+   * If true, the returned context will include the setAutoMaxHeight function.
+   * Default is false for backward compatibility.
+   */
+  enableSetAutoMaxHeight?: boolean;
+}
+
+/**
+ * Interface for the height control functionality
+ */
+export interface IHeightControl {
   /**
    * Sets the maximum height of the iframe in Workshop.
    * Only has an effect when the app is running inside an iframe AND
@@ -214,4 +225,9 @@ export type IWorkshopContextWithHeight<T extends IConfigDefinition> = IWorkshopC
    * @param height The maximum height in pixels
    */
   setAutoMaxHeight: (height: number) => void;
-};
+}
+
+/**
+ * Extends the IWorkshopContext with a setHeight function
+ */
+export type IWorkshopContextWithHeight<T extends IConfigDefinition> = IWorkshopContext<T> & IHeightControl;

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -35,21 +35,21 @@ import { IConfigDefinition } from "./types";
  * and depending on the field type, each property contains either a value in an async wrapper with setter methods or a method to execute a Workshop event.
  *
  * @param configFields: IConfigDefinition
- * @returns IAsyncValue<IWorkshopContext>, a context object in an async wrapper.
- */
-
-/**
- * Given the definition of config fields, returns a context object in an async wrapper with properties of the requested fields' IDs,
- * and depending on the field type, each property contains either a value in an async wrapper with setter methods or a method to execute a Workshop event.
- *
- * @param configFields: IConfigDefinition
  * @param options: IWorkshopContextOptions - Optional configuration options
  * @returns IAsyncValue<IWorkshopContext<T>> or IAsyncValue<IWorkshopContextWithHeight<T>> depending on options
  */
 export function useWorkshopContext<T extends IConfigDefinition>(
   configFields: IConfigDefinition,
+  options: { enableSetAutoMaxHeight: true }
+): IAsyncValue<IWorkshopContextWithHeight<T>>;
+export function useWorkshopContext<T extends IConfigDefinition>(
+  configFields: IConfigDefinition,
   options?: IWorkshopContextOptions
-): IAsyncValue<IWorkshopContext<T>|IWorkshopContextWithHeight<T>> {
+): IAsyncValue<IWorkshopContext<T>>;
+export function useWorkshopContext<T extends IConfigDefinition>(
+  configFields: IConfigDefinition,
+  options?: IWorkshopContextOptions
+): IAsyncValue<IWorkshopContextWithHeight<T>> | IAsyncValue<IWorkshopContext<T>> {
   // The context's definition
   const [configDefinition] = React.useState<IConfigDefinition>(configFields);
   // The context's values
@@ -136,7 +136,6 @@ export function useWorkshopContext<T extends IConfigDefinition>(
   }, [iframeWidgetId]);
 
   // Create the final context, conditionally including setAutoMaxHeight function
-  // Only include setAutoMaxHeight in the returned context if enableSetAutoMaxHeight is true
   const createFinalContext = React.useCallback(
     (context: IWorkshopContext<T>): IWorkshopContextWithHeight<T> | IWorkshopContext<T> => {
       // Only include setAutoMaxHeight in the returned context if enableSetAutoMaxHeight is true
@@ -144,7 +143,7 @@ export function useWorkshopContext<T extends IConfigDefinition>(
         return {
           ...context,
           setAutoMaxHeight,
-        };
+        } as IWorkshopContextWithHeight<T>;
       }
       
       // If enableSetAutoMaxHeight is not true, return the original context without setAutoMaxHeight

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -19,7 +19,7 @@ import {
   asyncValueFailed,
 } from "./types/loadingState";
 import { isInsideIframe, sendMessageToWorkshop } from "./utils";
-import { IWorkshopContext, IWorkshopContextWithHeight } from "./types/workshopContext";
+import { IWorkshopContext, IWorkshopContextWithHeight, IWorkshopContextOptions } from "./types/workshopContext";
 import { createDefaultConfigValueMap } from "./createDefaultConfigValueMap";
 import { transformConfigWorkshopContext } from "./transform-config";
 import {
@@ -38,9 +38,18 @@ import { IConfigDefinition } from "./types";
  * @returns IAsyncValue<IWorkshopContext>, a context object in an async wrapper.
  */
 
+/**
+ * Given the definition of config fields, returns a context object in an async wrapper with properties of the requested fields' IDs,
+ * and depending on the field type, each property contains either a value in an async wrapper with setter methods or a method to execute a Workshop event.
+ *
+ * @param configFields: IConfigDefinition
+ * @param options: IWorkshopContextOptions - Optional configuration options
+ * @returns IAsyncValue<IWorkshopContext<T>> or IAsyncValue<IWorkshopContextWithHeight<T>> depending on options
+ */
 export function useWorkshopContext<T extends IConfigDefinition>(
-  configFields: IConfigDefinition
-): IAsyncValue<IWorkshopContextWithHeight<T>> {
+  configFields: IConfigDefinition,
+  options?: IWorkshopContextOptions
+): IAsyncValue<IWorkshopContext<T>|IWorkshopContextWithHeight<T>> {
   // The context's definition
   const [configDefinition] = React.useState<IConfigDefinition>(configFields);
   // The context's values
@@ -126,21 +135,28 @@ export function useWorkshopContext<T extends IConfigDefinition>(
     }
   }, [iframeWidgetId]);
 
-  // Create the context with the setAutoMaxHeight function
-  const createContextWithHeight = React.useCallback(
-    (context: IWorkshopContext<T>): IWorkshopContextWithHeight<T> => {
-      return {
-        ...context,
-        setAutoMaxHeight,
-      };
+  // Create the final context, conditionally including setAutoMaxHeight function
+  // Only include setAutoMaxHeight in the returned context if enableSetAutoMaxHeight is true
+  const createFinalContext = React.useCallback(
+    (context: IWorkshopContext<T>): IWorkshopContextWithHeight<T> | IWorkshopContext<T> => {
+      // Only include setAutoMaxHeight in the returned context if enableSetAutoMaxHeight is true
+      if (options?.enableSetAutoMaxHeight === true) {
+        return {
+          ...context,
+          setAutoMaxHeight,
+        };
+      }
+      
+      // If enableSetAutoMaxHeight is not true, return the original context without setAutoMaxHeight
+      return context;
     },
-    [setAutoMaxHeight]
+    [setAutoMaxHeight, options?.enableSetAutoMaxHeight]
   );
 
   // If not inside iframe, simply return the loaded context with default values
   if (!insideIframe) {
     return asyncValueLoaded(
-      createContextWithHeight(
+      createFinalContext(
         transformConfigWorkshopContext(
           configDefinition,
           configValues,
@@ -162,7 +178,7 @@ export function useWorkshopContext<T extends IConfigDefinition>(
   // return the loaded context otherwise return that the context is loading.
   return workshopReceivedConfig
     ? asyncValueLoaded(
-        createContextWithHeight(
+        createFinalContext(
           transformConfigWorkshopContext(
             configDefinition,
             configValues,

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -127,6 +127,13 @@ export function useWorkshopContext<T extends IConfigDefinition>(
   // Create a function to set the auto max height of the iframe (only works when Workshop widget height is set to "auto (max)")
   const setAutoMaxHeight = React.useCallback((height: number) => {
     if (isInsideIframe() && iframeWidgetId != null) {
+      // Validate the height value
+      if (!Number.isInteger(height) || height < 0) {
+        console.warn("Invalid height value provided to setAutoMaxHeight. Height must be a non-negative integer.");
+        return;
+      }
+
+      // Send the message to Workshop
       sendMessageToWorkshop({
         type: MESSAGE_TYPES_TO_WORKSHOP.SET_AUTO_MAX_HEIGHT,
         iframeWidgetId,

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -131,7 +131,7 @@ export function useWorkshopContext<T extends IConfigDefinition>(
   const setAutoMaxHeight = React.useCallback((height: number) => {
     if (isInsideIframe() && iframeWidgetId != null) {
       sendMessageToWorkshop({
-        type: MESSAGE_TYPES_TO_WORKSHOP.SET_HEIGHT,
+        type: MESSAGE_TYPES_TO_WORKSHOP.SET_AUTO_MAX_HEIGHT,
         iframeWidgetId,
         height,
       });

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -42,11 +42,12 @@ import { IConfigDefinition } from "./types";
  */
 export type IWorkshopContextWithHeight<T extends IConfigDefinition> = IWorkshopContext<T> & {
   /**
-   * Sets the height of the iframe in Workshop.
-   * Only has an effect when the app is running inside an iframe.
-   * @param height The height in pixels
+   * Sets the maximum height of the iframe in Workshop.
+   * Only has an effect when the app is running inside an iframe AND
+   * the Workshop widget's height is set to "auto (max)".
+   * @param height The maximum height in pixels
    */
-  setHeight: (height: number) => void;
+  setAutoMaxHeight: (height: number) => void;
 }
 
 export function useWorkshopContext<T extends IConfigDefinition>(
@@ -126,25 +127,26 @@ export function useWorkshopContext<T extends IConfigDefinition>(
 
   const insideIframe = isInsideIframe();
 
-  // Create a function to set the height of the iframe
-  const setHeight = React.useCallback((height: number) => {
-    if (isInsideIframe()) {
+  // Create a function to set the auto max height of the iframe (only works when Workshop widget height is set to "auto (max)")
+  const setAutoMaxHeight = React.useCallback((height: number) => {
+    if (isInsideIframe() && iframeWidgetId != null) {
       sendMessageToWorkshop({
         type: MESSAGE_TYPES_TO_WORKSHOP.SET_HEIGHT,
+        iframeWidgetId,
         height,
       });
     }
-  }, []);
+  }, [iframeWidgetId]);
 
-  // Create the context with the setHeight function
+  // Create the context with the setAutoMaxHeight function
   const createContextWithHeight = React.useCallback(
     (context: IWorkshopContext<T>): IWorkshopContextWithHeight<T> => {
       return {
         ...context,
-        setHeight,
+        setAutoMaxHeight,
       };
     },
-    [setHeight]
+    [setAutoMaxHeight]
   );
 
   // If not inside iframe, simply return the loaded context with default values

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -37,9 +37,21 @@ import { IConfigDefinition } from "./types";
  * @param configFields: IConfigDefinition
  * @returns IAsyncValue<IWorkshopContext>, a context object in an async wrapper.
  */
+/**
+ * Extends the IWorkshopContext with a setHeight function
+ */
+export type IWorkshopContextWithHeight<T extends IConfigDefinition> = IWorkshopContext<T> & {
+  /**
+   * Sets the height of the iframe in Workshop.
+   * Only has an effect when the app is running inside an iframe.
+   * @param height The height in pixels
+   */
+  setHeight: (height: number) => void;
+}
+
 export function useWorkshopContext<T extends IConfigDefinition>(
   configFields: IConfigDefinition
-): IAsyncValue<IWorkshopContext<T>> {
+): IAsyncValue<IWorkshopContextWithHeight<T>> {
   // The context's definition
   const [configDefinition] = React.useState<IConfigDefinition>(configFields);
   // The context's values
@@ -114,14 +126,37 @@ export function useWorkshopContext<T extends IConfigDefinition>(
 
   const insideIframe = isInsideIframe();
 
+  // Create a function to set the height of the iframe
+  const setHeight = React.useCallback((height: number) => {
+    if (isInsideIframe()) {
+      sendMessageToWorkshop({
+        type: MESSAGE_TYPES_TO_WORKSHOP.SET_HEIGHT,
+        height,
+      });
+    }
+  }, []);
+
+  // Create the context with the setHeight function
+  const createContextWithHeight = React.useCallback(
+    (context: IWorkshopContext<T>): IWorkshopContextWithHeight<T> => {
+      return {
+        ...context,
+        setHeight,
+      };
+    },
+    [setHeight]
+  );
+
   // If not inside iframe, simply return the loaded context with default values
   if (!insideIframe) {
     return asyncValueLoaded(
-      transformConfigWorkshopContext(
-        configDefinition,
-        configValues,
-        setConfigValues,
-        iframeWidgetId
+      createContextWithHeight(
+        transformConfigWorkshopContext(
+          configDefinition,
+          configValues,
+          setConfigValues,
+          iframeWidgetId
+        )
       )
     );
   }
@@ -137,11 +172,13 @@ export function useWorkshopContext<T extends IConfigDefinition>(
   // return the loaded context otherwise return that the context is loading.
   return workshopReceivedConfig
     ? asyncValueLoaded(
-        transformConfigWorkshopContext(
-          configDefinition,
-          configValues,
-          setConfigValues,
-          iframeWidgetId
+        createContextWithHeight(
+          transformConfigWorkshopContext(
+            configDefinition,
+            configValues,
+            setConfigValues,
+            iframeWidgetId
+          )
         )
       )
     : asyncValueLoading();

--- a/src/useWorkshopContext.ts
+++ b/src/useWorkshopContext.ts
@@ -19,7 +19,7 @@ import {
   asyncValueFailed,
 } from "./types/loadingState";
 import { isInsideIframe, sendMessageToWorkshop } from "./utils";
-import { IWorkshopContext } from "./types/workshopContext";
+import { IWorkshopContext, IWorkshopContextWithHeight } from "./types/workshopContext";
 import { createDefaultConfigValueMap } from "./createDefaultConfigValueMap";
 import { transformConfigWorkshopContext } from "./transform-config";
 import {
@@ -37,18 +37,6 @@ import { IConfigDefinition } from "./types";
  * @param configFields: IConfigDefinition
  * @returns IAsyncValue<IWorkshopContext>, a context object in an async wrapper.
  */
-/**
- * Extends the IWorkshopContext with a setHeight function
- */
-export type IWorkshopContextWithHeight<T extends IConfigDefinition> = IWorkshopContext<T> & {
-  /**
-   * Sets the maximum height of the iframe in Workshop.
-   * Only has an effect when the app is running inside an iframe AND
-   * the Workshop widget's height is set to "auto (max)".
-   * @param height The maximum height in pixels
-   */
-  setAutoMaxHeight: (height: number) => void;
-}
 
 export function useWorkshopContext<T extends IConfigDefinition>(
   configFields: IConfigDefinition


### PR DESCRIPTION
## Feature: Dynamic iframe height adjustment

This PR adds support for dynamically adjusting the height of iframes in Workshop, allowing for more responsive and adaptive custom widgets.

### Changes

- Extended the `WorkshopContext` interface with a new `setHeight` function
- Added a new message type `SET_HEIGHT` to communicate height changes to Workshop
- Implemented the setHeight functionality that works when the app is running inside an iframe
- Updated the return type of `useWorkshopContext` to include the new setHeight function

### Usage

Developers can now adjust the height of their iframe widgets dynamically:

```typescript
const context = useWorkshopContext(configFields);

// Later in your component:
if (context.state === 'loaded') {
  // Set the iframe height to 500 pixels
  context.value.setHeight(500);
}
```

This is particularly useful for:
- Widgets with dynamic content that changes in height
- Responsive designs that need to adapt to different screen sizes
- Preventing unnecessary scrollbars within the iframe